### PR TITLE
add argument: execution directory

### DIFF
--- a/src/bashDebug.ts
+++ b/src/bashDebug.ts
@@ -8,6 +8,7 @@ import {basename} from 'path';
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 
+	executionDirectory: string;
 	scriptPath: string;
 	commandLineArguments: string;
 	bashDbPath: string;
@@ -94,6 +95,7 @@ class BashDebugSession extends DebugSession {
 			mkfifo "${fifo_path}"
 			cat "${fifo_path}" >&${this.debugPipeIndex} &
 			exec 4>"${fifo_path}" 		# Keep open for writing, bashdb seems close after every write.
+			cd ${args.executionDirectory}
 			cat | ${args.bashDbPath} --quiet --tty "${fifo_path}" -- "${args.scriptPath}" ${args.commandLineArguments}
 
 			cleanup`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ const initialConfigurations = {
 				name: 'Bash-Debug (select script from list of sh files)',
 				type: 'bashdb',
 				request: 'launch',
+				executionDirectory: '${workspaceRoot}',
 				scriptPath: '${command:SelectScriptName}',
 				commandLineArguments: '',
 				windows: {
@@ -30,6 +31,7 @@ const initialConfigurations = {
 				name: 'Bash-Debug (hardcoded script name)',
 				type: 'bashdb',
 				request: 'launch',
+				executionDirectory: '${workspaceRoot}',
 				scriptPath: '${workspaceRoot}/path/to/script.sh',
 				commandLineArguments: '',
 				windows: {
@@ -50,6 +52,7 @@ const initialConfigurations = {
 				name: 'Bash-Debug (type in script name)',
 				type: 'bashdb',
 				request: 'launch',
+				executionDirectory: '${workspaceRoot}',
 				scriptPath: '${workspaceRoot}/${command:AskForScriptName}',
 				commandLineArguments: '',
 				windows: {


### PR DESCRIPTION
Maybe the variable name `executionDirectory` is ambiguous, give me other proposal if any.
How about `workingDirectory` instead?