### PR TITLE
Fix debugger breakpoint set

### DIFF
--- a/src/bashDebug.ts
+++ b/src/bashDebug.ts
@@ -139,7 +139,7 @@ export class BashDebugSession extends LoggingDebugSession {
 			"${args.pathCat}" "${fifo_path}" >&${this.debugPipeIndex} &
 			exec 4>"${fifo_path}" 		# Keep open for writing, bashdb seems close after every write.
 			cd "${args.cwd}"
-			"${args.pathCat}" | "${args.pathBashdb}" --tty "${fifo_path}" -- "${args.program}" ${args.args.join(" ")}
+			"${args.pathCat}" | "${args.pathBashdb}" --quiet --tty "${fifo_path}" -- "${args.program}" ${args.args.join(" ")}
 			`
 		], { stdio: ["pipe", "pipe", "pipe", "pipe"] });
 

--- a/src/bashDebug.ts
+++ b/src/bashDebug.ts
@@ -139,7 +139,7 @@ export class BashDebugSession extends LoggingDebugSession {
 			"${args.pathCat}" "${fifo_path}" >&${this.debugPipeIndex} &
 			exec 4>"${fifo_path}" 		# Keep open for writing, bashdb seems close after every write.
 			cd "${args.cwd}"
-			"${args.pathCat}" | "${args.pathBashdb}" --quiet --tty "${fifo_path}" -- "${args.program}" ${args.args.join(" ")}
+			"${args.pathCat}" | "${args.pathBashdb}" --tty "${fifo_path}" -- "${args.program}" ${args.args.join(" ")}
 			`
 		], { stdio: ["pipe", "pipe", "pipe", "pipe"] });
 
@@ -220,7 +220,7 @@ export class BashDebugSession extends LoggingDebugSession {
 
 		const sourcePath = (process.platform === "win32") ? getWSLPath(args.source.path) : args.source.path;
 
-		let setBreakpointsCommand = `print 'delete <${this.currentBreakpointIds[args.source.path].join(" ")}>'\ndelete ${this.currentBreakpointIds[args.source.path].join(" ")}\nload ${sourcePath}\n`;
+		let setBreakpointsCommand = `print 'delete <${this.currentBreakpointIds[args.source.path].join(" ")}>'\ndelete ${this.currentBreakpointIds[args.source.path].join(" ")}\nyes\nload ${sourcePath}\n`;
 		if (args.breakpoints) {
 			args.breakpoints.forEach((b) => { setBreakpointsCommand += `print ' <${sourcePath}:${b.line}> '\nbreak ${sourcePath}:${b.line}\n` });
 		}


### PR DESCRIPTION
The fix is about the error reported by trace log:

> To client: {"seq":0,"type":"event","event":"output","body":{"category":"console","output":"Please try again entering 'yes' or 'no'.\nI don't understand "print".\nPlease try again entering 'yes' or 'no'.\n"}}
> Please try again entering 'yes' or 'no'.

At line **bashDebug.ts:223** the **bashdb** (ver. 4.4-0.94) command needs **yes** after issuing the **delete** command.

This PR refers to [my issue 73[(https://github.com/rogalmic/vscode-bash-debug/issues/73).

Could you kindly merge it and make it available for update on the _marketplace_?

Thank you so much!
Antonio