### PR TITLE
fix error msg re unfindable pathBash on Windows

### DIFF
--- a/src/bashRuntime.ts
+++ b/src/bashRuntime.ts
@@ -112,7 +112,12 @@ export function validatePath(cwd: string,
 			return `Error: cwd (${cwd}) does not exist.` + stderrContent;
 		}
 		case validatePathResult.notFoundBash: {
-			return `Error: bash not found. (pathBash: ${pathBash})` + stderrContent;
+			if ( process.platform == "win32" )
+			{
+				return `Error: WSL bash (mandatory on Windows) is not found. pathBash currently unused. (pathBash: ${pathBash})` + stderrContent;
+			} else {
+				return `Error: bash not found. (pathBash: ${pathBash})` + stderrContent;
+			}
 		}
 		case validatePathResult.notFoundBashdb: {
 			return `Error: bashdb not found. (pathBashdb: ${pathBashdb})` + stderrContent;


### PR DESCRIPTION
Fixes #106.

This fix should save Windows people's time when trying to find out why no configuration of `pathBash` really works: For the time being the extension does not work on Windows when WSL bash is not installed (cf. #106 for details).

@rogalmic Please do feel free to edit the code adjustments and/or change the error message, of course. I changed and tested the code in my local installation folder.